### PR TITLE
Add MessageProcessor and insert_messsage_processor to batcher

### DIFF
--- a/furious/batcher.py
+++ b/furious/batcher.py
@@ -148,40 +148,6 @@ class MessageProcessor(Async):
         return int(time.time() / max(1, self.frequency))
 
 
-def insert_messsage_processor(job, args, kwargs, queue_name, freq=30, tag=None,
-                              countdown=None, name=None):
-    """Return the :class: `MessageProcessor` created and started. Will set the
-    countdown and name as task_args if they aren't None.
-
-    :param job: Python function to run within the Async task
-    :param args: :class: `tuple` of arguments to pass to the job when it runs.
-    :param kwargs: :class: `dict` of optional arguments to pass to the job
-                   when it runs.
-    :param queue_name: :class: `str` Queue that the async task will run within.
-    :param freq: :class: `int` The frequency throttle for how many proccessing
-                 jobs can be inserted at one time.
-    :param tag: :class: `str` Pull queue tag used for fetching the work items.
-    :param countdown: :class: `int` Delay before running the job.
-    :param name: :class: `str` Part of the unique name of the task.
-
-    :return: :class: `MessageProcessor` created and started.
-    """
-    task_args = {}
-
-    if countdown:
-        task_args['countdown'] = countdown
-
-    if name:
-        task_args['name'] = name
-
-    processor = MessageProcessor(job, args, kwargs, queue=queue_name,
-                                 freq=freq, tag=tag, task_args=task_args)
-
-    processor.start()
-
-    return processor
-
-
 def fetch_messages():
     pass
 

--- a/furious/tests/test_batcher.py
+++ b/furious/tests/test_batcher.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from mock import Mock, patch
+from mock import patch
 
 
 class MessageTestCase(unittest.TestCase):
@@ -353,78 +353,3 @@ class MessageProcessorTestCase(unittest.TestCase):
 
         cache.get.assert_called_once_with('agg-batch-processor')
         cache.add.assert_called_once_with('agg-batch-processor', 1)
-
-
-class InsertMessageProcessorTestCase(unittest.TestCase):
-
-    def test_no_countdown_or_name(self):
-        """Ensure that if no countdown or name are set that they aren't passed
-        in as task_args to the MessageProcessor.
-        """
-        from furious.batcher import insert_messsage_processor
-        from furious.batcher import MessageProcessor
-
-        with patch.object(MessageProcessor, 'start') as start:
-            processor = insert_messsage_processor(
-                'job', None, None, 'queue-name')
-
-            options = {
-                'queue': 'queue-name',
-                'job': ('job', None, None),
-                'task_args': {}
-            }
-            self.assertEqual(processor.get_options(), options)
-            self.assertEqual(processor.tag, 'processor')
-            self.assertEqual(processor.frequency, 30)
-
-        start.assert_called_once_with()
-
-    def test_countdown_passed_in(self):
-        """Ensure that if countdown is set that it's passed as a task_arg to
-        the MessageProcessor.
-        """
-        from furious.batcher import insert_messsage_processor
-        from furious.batcher import MessageProcessor
-
-        with patch.object(MessageProcessor, 'start') as start:
-            processor = insert_messsage_processor(
-                'job', None, None, 'queue-name', countdown=100)
-
-            task_args = {
-                'countdown': 100
-            }
-            self.assertEqual(processor.get_task_args(), task_args)
-
-        start.assert_called_once_with()
-
-    def test_name_passed_in(self):
-        """Ensure that if name is set that it's passed as a task_arg to the
-        MessageProcessor.
-        """
-        from furious.batcher import insert_messsage_processor
-        from furious.batcher import MessageProcessor
-
-        with patch.object(MessageProcessor, 'start') as start:
-            processor = insert_messsage_processor(
-                'job', None, None, 'queue-name', name='name')
-
-            task_args = {
-                'name': 'name'
-            }
-            self.assertEqual(processor.get_task_args(), task_args)
-
-        start.assert_called_once_with()
-
-    def test_tag_passed_in(self):
-        """Ensure that if tag is set that it's set on the MessageProcessor."""
-
-        from furious.batcher import insert_messsage_processor
-        from furious.batcher import MessageProcessor
-
-        with patch.object(MessageProcessor, 'start') as start:
-            processor = insert_messsage_processor(
-                'job', None, None, 'queue-name', tag='tag')
-
-            self.assertEqual(processor.tag, 'tag')
-
-        start.assert_called_once_with()


### PR DESCRIPTION
Add MessageProcessor and insert_messsage_processor to batcher

Add MessageProcessor Async object to the batcher module. This object will
insert a task to pull tasks off a pull queue. It will try to insert them
serially using a memcache marker based off a time frequency formula.

Add insert_messsage_processor function that wraps creating a MessageProcessor
and inserting it.

Also fix broken unit test around default pull queue for messages.

@robertkluin-wf @tannermiller-wf @ericolson-wf
