### PR TITLE
Fix callback mocks on test_AbortAndRestart.

### DIFF
--- a/furious/tests/test_processors.py
+++ b/furious/tests/test_processors.py
@@ -223,8 +223,8 @@ class TestRunJob(unittest.TestCase):
         mock_error = Mock()
 
         work = Async(target='dir',
-                     success=mock_success,
-                     error=mock_error)
+                     callbacks={'success': mock_success,
+                                'error': mock_error})
 
         with _ExecutionContext(work):
             run_job()


### PR DESCRIPTION
The callbacks were not even close to being specified correctly before.
This has been fixed and the test is not more correct that it was.
