### PR TITLE
Fix the broken batcher example

### DIFF
--- a/example/templates/batcher.html
+++ b/example/templates/batcher.html
@@ -39,7 +39,7 @@
     </div>
     <script>
       (function(){
-        var Batcher = this..Batcher = {};
+        var Batcher = this.Batcher = {};
 
         Batcher.DONE_STATE = 4
 


### PR DESCRIPTION
The CAS needed to do a gets instead of get. Also needed to check to do an add
first as the cas will fail if the key doesn't already exist.

Also fixed a syntax bug in the javscript portion of the template.

@robertkluin-wf @johnlockwood-wf @tannermiller-wf @ericolson-wf
