### PR TITLE
(Deprecated, new version linked) Max recursion

### DIFF
--- a/furious/processors.py
+++ b/furious/processors.py
@@ -73,7 +73,7 @@ def run_job():
         async.result = function(*args, **kwargs)
     except AbortAndRestart as restart:
         logging.info('Async job was aborted and restarted: %r', restart)
-        async.update_options(current_depth=next_depth)
+        async.update_options(current_depth=next_depth, max_depth=max_depth)
         async._restart()
         return
     except Exception as e:
@@ -85,7 +85,8 @@ def run_job():
 
     processor_result = results_processor()
     if isinstance(processor_result, (Async, Context)):
-        processor_result.update_options(current_depth=next_depth)
+        processor_result.update_options(current_depth=next_depth,
+                                        max_depth=max_depth)
         processor_result.start()
 
 


### PR DESCRIPTION
Here is the implementation for https://github.com/WebFilings/furious/issues/41

They `Async` now keeps a `current_depth` and `max_depth` in it's options which the `run_job` function checks and increments. If the current_depth exceeds max depth then an INFO level logging message is output and execution ceases.
