### PR TITLE
Remove task name upon restart

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -382,9 +382,16 @@ class Async(object):
 
         self._executing = False
 
+        # Increment restart_count
         restart_count = self.get_options().get('_restart_count', -1)
         restart_count += 1
-        self.update_options(_restart_count=restart_count)
+
+        # Remove task name
+        task_args = self.get_task_args()
+        if 'name' in task_args:
+            del task_args['name']
+
+        self.update_options(task_args=task_args, _restart_count=restart_count)
 
         if restart_count < MAX_RESTARTS:
             return self.start()

--- a/furious/tests/test_async.py
+++ b/furious/tests/test_async.py
@@ -656,6 +656,18 @@ class TestAsync(unittest.TestCase):
 
         self.assertRaises(NotExecutingError, async_job._restart,)
 
+    def test_restart_remove_name(self):
+        """Ensure that any set task name is removed upon restart."""
+        from furious.async import Async
+
+        async_job = Async("something", task_args={'name': 'a_name'})
+        async_job._executing = True
+
+        async_job._restart()
+
+        self.assertEqual(0, async_job.get_options()['_restart_count'])
+        self.assertNotIn('name', async_job.get_task_args())
+
     def test_update_recursion_level_defaults(self):
         """Ensure that defaults (1, MAX_DEPTH) are set correctly."""
         from furious.async import Async


### PR DESCRIPTION
Remove the task name upon restart, in the case of our batcher (with our
new async subclassing rules) will keep appending new names to old names
created ugly things that we don't need and break the name duping logic.

Added test!
