### PR TITLE
GAE Module support for Furious

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -84,7 +84,13 @@ __all__ = ['ASYNC_DEFAULT_QUEUE', 'ASYNC_ENDPOINT', 'Async', 'defaults']
 
 
 ASYNC_DEFAULT_QUEUE = 'default'
-ASYNC_ENDPOINT = '/_ah/queue/async'
+
+try:
+    from settings import FURIOUS_URL as ASYNC_ENDPOINT
+except ImportError:
+    ASYNC_ENDPOINT = '/_ah/queue/async'
+
+
 MAX_DEPTH = 100
 MAX_RESTARTS = 10
 DISABLE_RECURSION_CHECK = -1


### PR DESCRIPTION
Given the way that [GAE Modules](https://developers.google.com/appengine/docs/python/modules/) directs traffic to the main application or sub-modules, if furious exists in both places, a prefix needs to be added to the furious endpoint to make sure it executes the correct code.

To make this easier, adding a FURIOUS_URL constant to settings.py will allow users to direct the appropriate furious traffic to the correct, related endpoint.   
