### PR TITLE
Switch the context id on an Async to be passed in via the options or be pulled from the current context.

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -108,6 +108,7 @@ class Async(object):
 
         self._initialize_recursion_depth()
 
+        self._context_id = self._get_context_id()
         self._id = self._get_id()
 
         self._execution_context = None
@@ -384,17 +385,6 @@ class Async(object):
         return id
 
     @property
-    def context_id(self):
-        """If this async has a context id, return it; else raise
-        NotInContextError.
-        """
-        context_id = self._options.get('_context_id')
-        if context_id:
-            return context_id
-
-        raise errors.NotInContextError("Context ID not set.")
-
-    @property
     def id(self):
         """Return this Async's ID value."""
         return self._id
@@ -415,6 +405,35 @@ class Async(object):
         # Increment and store
         self.update_options(_recursion={'current': current_depth,
                                         'max': max_depth})
+
+    @property
+    def context_id(self):
+        """Return this Async's Context Id if it exists."""
+        if not self._context_id:
+            self._context_id = self._get_context_id()
+
+        return self._context_id
+
+    def _get_context_id(self):
+        """If this async is in a context set the context id."""
+        context_id = self._options.get('context_id')
+
+        if context_id:
+            return context_id
+
+        from furious.context import get_current_context
+
+        try:
+            context = get_current_context()
+        except errors.NotInContextError:
+            context = None
+
+        if context:
+            context_id = context.id
+
+        self.update_options(context_id=context_id)
+
+        return context_id
 
 
 def async_from_options(options):

--- a/furious/tests/context/test_context.py
+++ b/furious/tests/context/test_context.py
@@ -287,11 +287,12 @@ class TestContext(unittest.TestCase):
 
         options = {
             'id': 'someid',
+            'context_id': 'contextid',
             'persistence_engine': 'persistence_engine',
             'callbacks': {
                 'success': self.__class__.test_to_dict_with_callbacks,
                 'failure': "failure_function",
-                'exec': Async(target=dir, id='blargh')
+                'exec': Async(target=dir, id='blargh', context_id='contextid')
             }
         }
 
@@ -310,6 +311,7 @@ class TestContext(unittest.TestCase):
                 'failure': "failure_function",
                 'exec': {'job': ('dir', None, None),
                          'id': 'blargh',
+                         'context_id': 'contextid',
                          '_recursion': {'current': 0, 'max': 100},
                          '_type': 'furious.async.Async'}
             }
@@ -351,7 +353,8 @@ class TestContext(unittest.TestCase):
             'success': ("furious.tests.context.test_context."
                         "TestContext.test_to_dict_with_callbacks"),
             'failure': "dir",
-            'exec': {'job': ('id', None, None), 'id': 'myid'}
+            'exec': {'job': ('id', None, None), 'id': 'myid',
+                     'context_id': 'contextid'}
         }
 
         context = Context.from_dict({'callbacks': callbacks})
@@ -366,6 +369,7 @@ class TestContext(unittest.TestCase):
 
         correct_dict = {'job': ('id', None, None),
                         'id': 'myid',
+                        'context_id': 'contextid',
                         '_recursion': {'current': 0, 'max': 100},
                         '_type': 'furious.async.Async'}
 
@@ -379,6 +383,7 @@ class TestContext(unittest.TestCase):
         options = {
             'id': 123098,
             'insert_tasks': 'furious.context.context._insert_tasks',
+            'context_id': 'contextid',
             'persistence_engine':
             'furious.job_utils.get_function_path_and_options',
             '_tasks_inserted': True,

--- a/furious/tests/test_async.py
+++ b/furious/tests/test_async.py
@@ -231,28 +231,23 @@ class TestAsync(unittest.TestCase):
         from furious.async import Async
 
         job = Async('somehting')
-        job.update_options(_context_id='blarghahahaha')
+        job.update_options(context_id='blarghahahaha')
         self.assertEqual(job.context_id, 'blarghahahaha')
 
     def test_no_context_id(self):
-        """Ensure calling context_id when none exists raises error."""
+        """Ensure calling context_id when none exists returns None."""
         from furious.async import Async
-        from furious.errors import NotInContextError
 
         job = Async('somehting')
-        try:
-            job.context_id
-        except NotInContextError:
-            return
-
-        raise AssertionError('NotInContextError was not raised.')
+        self.assertIsNone(job.context_id)
 
     def test_decorated_options(self):
         """Ensure the defaults decorator sets Async options."""
         from furious.async import Async
         from furious.async import defaults
 
-        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'thing'}
+        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'thing',
+                   'context_id': None}
 
         @defaults(**options.copy())
         def some_function():
@@ -270,7 +265,8 @@ class TestAsync(unittest.TestCase):
         from furious.async import Async
         from furious.async import defaults
 
-        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'wrong'}
+        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'wrong',
+                   'context_id': None}
 
         @defaults(**options.copy())
         def some_function():
@@ -314,7 +310,8 @@ class TestAsync(unittest.TestCase):
         """Ensure update_options updates the options."""
         from furious.async import Async
 
-        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'xx'}
+        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'xx',
+                   'context_id': None}
 
         job = Async("nonexistant")
         job.update_options(**options.copy())
@@ -329,7 +326,8 @@ class TestAsync(unittest.TestCase):
         """Ensure update_options supersedes the options set in init."""
         from furious.async import Async
 
-        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'wrong'}
+        options = {'value': 1, 'other': 'zzz', 'nested': {1: 1}, 'id': 'wrong',
+                   'context_id': None}
 
         job = Async("nonexistant", **options.copy())
 
@@ -427,7 +425,8 @@ class TestAsync(unittest.TestCase):
 
         task_args = {'other': 'zzz', 'nested': 1}
         headers = {'some': 'thing', 'fun': 1}
-        options = {'headers': headers, 'task_args': task_args, 'id': 'me'}
+        options = {'headers': headers, 'task_args': task_args, 'id': 'me',
+                   'context_id': None}
 
         job = Async('nonexistant', **options.copy())
 
@@ -442,6 +441,7 @@ class TestAsync(unittest.TestCase):
         from furious.async import Async
 
         options = {'id': 'anident',
+                   'context_id': 'contextid',
                    'callbacks': {
                        'success': self.__class__.test_to_dict_with_callbacks,
                        'failure': "failure_function",
@@ -457,6 +457,7 @@ class TestAsync(unittest.TestCase):
             'failure': "failure_function",
             'exec': {'job': ('dir', None, None),
                      'id': 'subidnet',
+                     'context_id': None,
                      '_recursion': {'current': 0, 'max': 100},
                      '_type': 'furious.async.Async'}
         }
@@ -507,6 +508,7 @@ class TestAsync(unittest.TestCase):
 
         correct_options = {'job': ('dir', None, None),
                            'id': 'petey',
+                           'context_id': None,
                            '_recursion': {'current': 0, 'max': 100},
                            '_type': 'furious.async.Async'}
 
@@ -528,6 +530,7 @@ class TestAsync(unittest.TestCase):
             'persistence_engine': 'furious.extras.appengine.ndb_persistence',
             '_recursion': {'current': 1, 'max': 100},
             '_type': 'furious.async.Async',
+            'context_id': None
         }
 
         async_job = Async.from_dict(options)
@@ -560,7 +563,7 @@ class TestAsync(unittest.TestCase):
 
         task_args = {'eta': eta_posix}
         options = {'job': job, 'headers': headers, 'task_args': task_args,
-                   'id': 'ident'}
+                   'id': 'ident', 'context_id': 'contextid'}
 
         task = Async.from_dict(options).to_task()
 

--- a/furious/tests/test_batcher.py
+++ b/furious/tests/test_batcher.py
@@ -373,6 +373,7 @@ class MessageProcessorTestCase(unittest.TestCase):
                     'max': 100
                 },
                 '_type': 'furious.batcher.MessageProcessor',
+                'context_id': None
             }),
             'countdown': 30,
             'name': 'processor-processor-current-batch-3',


### PR DESCRIPTION
Switch the context id on an Async to be passed in via the options or be pulled from the current context.

This allows the context to pass its id down to the context. This will be used by
the completion logic.
