### PR TITLE
Tweak the test commands in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ $(BUILD_DIR)/pip-dev.log: requirements.txt
 	$(PIP) install -Ur requirements.txt | tee $(BUILD_DIR)/pip-dev.log
 
 unit: clean
-	nosetests --with-coverage
+	nosetests
 
 integrations:
-	nosetests --logging-level=ERROR -a slow 
+	nosetests --logging-level=ERROR -a slow --with-coverage
 
-test: clean unit integrations
+test: clean integrations
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ cover-package=furious
 cover-branches=True
 
 exclude-dir=furious/tests/dummy_module
-
+ATTR=!slow


### PR DESCRIPTION
Switch the test commands to be a little more user friendly in the Makefile.

`make unit` is now really fast with no reporting
`make integration` is slower

`make test` does it all with reporting

Might make sense to remove the reporting from `make integration` as well and just
have that run on `make test`

@robertkluin-wf @tannermiller-wf @rosshendrickson-wf @johnlockwood-wf
