### PR TITLE
Allow AutoContexts to be created from context.new()

### DIFF
--- a/furious/context/__init__.py
+++ b/furious/context/__init__.py
@@ -52,7 +52,7 @@ execution_context_from_async = _execution.execution_context_from_async
 
 def new(batch_size=None, **options):
     """Get a new furious context and add it to the registry. If a batch size is
-    specified, use an auto context which inserts tasks in batches as they are
+    specified, use an AutoContext which inserts tasks in batches as they are
     added to the context.
     """
 

--- a/furious/tests/context/test_context.py
+++ b/furious/tests/context/test_context.py
@@ -33,7 +33,7 @@ class TestNew(unittest.TestCase):
         self.assertIsInstance(new(), Context)
 
     def test_new_auto_context(self):
-        """Ensure new returns a new auto context when batch size is specified.
+        """Ensure new returns a new AutoContext when batch size is specified.
         """
         from furious.context import AutoContext
         from furious.context import new


### PR DESCRIPTION
This adds a batch_size kwarg to context.new which results in an
AutoContext being registered instead of a regular Context. Aside from
being more convenient, this allows the AutoContext behavior to be
abstracted from the client. This helps in the event that we decide to
bring AutoContext's batching functionality into Context, removing the
need for the subclass.

@robertkluin-wf @ericolson-wf @beaulyddon-wf @tannermiller-wf
