### PR TITLE
Raise exception with correct traceback

### DIFF
--- a/furious/processors.py
+++ b/furious/processors.py
@@ -122,8 +122,8 @@ def _process_results():
         callback = callbacks.get('error')
 
         if not callback:
-            raise (async.result.payload.exception, None,
-                   async.result.payload.traceback)
+            raise async.result.payload.exception, None, \
+                async.result.payload.traceback[2]
 
     return _execute_callback(async, callback)
 


### PR DESCRIPTION
This corrects issue #143 where exceptions are raised in the results
processor with the incorrect traceback.

@beaulyddon-wf @rosshendrickson-wf @andreleblanc-wf @robertkluin-wf
