### PR TITLE
completion_retry - If a marker/context is already complete, re-execute the completion tasks, in case they failed to execute on the first attempt.

### DIFF
--- a/furious/context/context.py
+++ b/furious/context/context.py
@@ -204,7 +204,7 @@ class Context(object):
         callbacks[event] = handler
         self._options['callbacks'] = callbacks
 
-    def exec_event_handler(self, event):
+    def exec_event_handler(self, event, transactional=False):
         """Execute the Async set to be run on event."""
         # QUESTION: Should we raise an exception if `event` is not in some
         # known event-type list?
@@ -216,7 +216,7 @@ class Context(object):
         if not handler:
             raise Exception('Handler not defined!!!')
 
-        handler.start()
+        handler.start(transactional=transactional)
 
     def add(self, target, args=None, kwargs=None, **options):
         """Add an Async job to this context.

--- a/furious/extras/appengine/ndb_persistence.py
+++ b/furious/extras/appengine/ndb_persistence.py
@@ -166,10 +166,7 @@ def _completion_checker(async_id, context_id):
     if not done:
         return False
 
-    first_complete = _mark_context_complete(marker, context, has_errors)
-
-    if first_complete:
-        _insert_post_complete_tasks(context)
+    _mark_context_complete(marker, context, has_errors)
 
     return True
 
@@ -233,6 +230,9 @@ def _mark_context_complete(marker, context, has_errors):
     current.has_errors = has_errors
     current.put()
 
+    # Kick off completion tasks.
+    _insert_post_complete_tasks(context)
+
     return True
 
 
@@ -242,7 +242,7 @@ def _insert_post_complete_tasks(context):
     logging.debug("Context %s is complete.", context.id)
 
     # Async event handlers
-    context.exec_event_handler('complete')
+    context.exec_event_handler('complete', transactional=True)
 
     # Insert cleanup tasks
     try:


### PR DESCRIPTION
This address issue #144 where a BulkAdd() error when executing the completion handler will retry, but won't execute the completion handler.

@beaulyddon-wf @rosshendrickson-wf @tylertreat-wf
