### PR TITLE
Add stat logging middleware

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -178,7 +178,7 @@ class Async(object):
     @property
     def _function_path(self):
         # DEPRECATED: Hanging around for backwards compatibility.
-        return self.function_path()
+        return self.function_path
 
     @property
     def job(self):

--- a/furious/config.py
+++ b/furious/config.py
@@ -50,10 +50,11 @@ def get_default_persistence_engine(known_modules=PERSISTENCE_MODULES):
     return _get_configured_module('persistence', known_modules=known_modules)
 
 
-def _get_configured_module(option_name, known_modules=None):
+def get_module(option_name, known_modules=None):
     """Get the module specified by the value of option_name. The value of the
     configuration option will be used to load the module by name from the known
-    module list or treated as a path if not found in known_modules.
+    module list or treated as a path if not found in known_modules. If the
+    module is not found then None will be returned.
     Args:
         option_name: name of persistence module
         known_modules: dictionary of module names and module paths,
@@ -61,9 +62,31 @@ def _get_configured_module(option_name, known_modules=None):
     Returns:
         module of the module path matching the name in known_modules
     """
+    return _get_configured_module(option_name, known_modules=known_modules,
+                                  verify_exists=False)
+
+
+def _get_configured_module(option_name, known_modules=None,
+                           verify_exists=True):
+    """Get the module specified by the value of option_name. The value of the
+    configuration option will be used to load the module by name from the known
+    module list or treated as a path if not found in known_modules.
+    Args:
+        option_name: name of persistence module
+        known_modules: dictionary of module names and module paths,
+            ie: {'ndb':'furious.extras.appengine.ndb_persistence'}
+        verify_exists: boolean of wether to ensure the keys and modules exist
+            or just return if they don't.
+    Returns:
+        module of the module path matching the name in known_modules
+    """
     from furious.job_utils import path_to_reference
 
     config = get_config()
+
+    if not verify_exists and option_name not in config:
+        return
+
     option_value = config[option_name]
 
     # If no known_modules were give, make it an empty dict.
@@ -71,6 +94,7 @@ def _get_configured_module(option_name, known_modules=None):
         known_modules = {}
 
     module_path = known_modules.get(option_value) or option_value
+
     return path_to_reference(module_path)
 
 

--- a/furious/extras/appengine/stat_processor.py
+++ b/furious/extras/appengine/stat_processor.py
@@ -5,7 +5,7 @@ import os
 class StatProcessor(object):
 
     def __init__(self, env, recorder):
-        """Initialize the stat procossor with the environment variables and
+        """Initialize the stat processor with the environment variables and
         recorder.
         """
         self.env = {}

--- a/furious/extras/appengine/stat_processor.py
+++ b/furious/extras/appengine/stat_processor.py
@@ -1,0 +1,57 @@
+import re
+import os
+
+
+class StatProcessor(object):
+
+    def __init__(self, env, recorder):
+        """Initialize the stat procossor with the environment variables and
+        recorder.
+        """
+        self.env = {}
+        self.recorder = recorder
+
+        self.env.update(env if env else os.environ)
+
+    def get_request_details(self):
+        """Pull the appengine details from the environement variables (which
+        will also include the request args.
+        """
+        return {
+            'app_id': self._get_env_info('APPLICATION_ID', ''),
+            'version_id': self._get_env_info('CURRENT_VERSION_ID', ''),
+            'module_id': self._get_env_info('CURRENT_MODULE_ID', ''),
+            'instance_id': self._get_env_info('INSTANCE_ID', ''),
+            'request_id': self.env.get('REQUEST_LOG_ID', ''),
+        }
+
+    def get_host(self):
+        """Return the server name or application name from the environemnt."""
+        return self.env.get('SERVER_NAME') or self.env.get('APPLICATION_ID',
+                                                           'NO_APPID')
+
+    def get_task_stats(self):
+        """Processes the environment data from task requests to get some
+        analytical data.
+        """
+
+        task_eta = float(self.env.get('HTTP_X_APPENGINE_TASKETA', 0.0))
+
+        return {
+            'retry_count': self.env.get('HTTP_X_APPENGINE_TASKRETRYCOUNT', 0),
+            'execution_count': self.env.get(
+                'HTTP_X_APPENGINE_TASKEXECUTIONCOUNT', 0),
+            'task_eta': task_eta,
+            'gae_latency_seconds': self.recorder.start_timestamp - task_eta,
+        }
+
+    def _get_env_info(self, env_id, default=''):
+        """Return the string pulled from os.environ with special characters
+        removed.
+        """
+        return _clean_string(self.env.get(env_id, default))
+
+
+def _clean_string(string):
+    """Return the string with special characters removed."""
+    return re.sub('[^a-zA-Z0-9\n]', '_', string.strip()).strip('_')

--- a/furious/extras/appengine/stat_processor.py
+++ b/furious/extras/appengine/stat_processor.py
@@ -27,8 +27,7 @@ class StatProcessor(object):
 
     def get_host(self):
         """Return the server name or application name from the environemnt."""
-        return self.env.get('SERVER_NAME') or self.env.get('APPLICATION_ID',
-                                                           'NO_APPID')
+        return self.env.get('APPLICATION_ID', 'NO_APPID')
 
     def get_task_stats(self):
         """Processes the environment data from task requests to get some

--- a/furious/extras/middleware/stat_logger.py
+++ b/furious/extras/middleware/stat_logger.py
@@ -1,0 +1,173 @@
+#
+# Copyright 2013 WebFilings, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+
+from furious.config import get_config
+
+from furious.extras.stat_recorder import Recorder
+
+DEFAULT_SOCKET_PORT = 1300
+
+
+class CONNECTIONS:
+
+    HTTP = 'http'
+    TCP = 'tcp'
+    UDP = 'upd'
+
+
+def furious_wsgi_middleware(app):
+
+    def furious_wsgi_wrapper(environ, start_response):
+        """Outer wrapper function around the WSGI protocol.
+
+        The top-level furious() function returns this
+        function to the caller instead of the app class or function passed
+        in.  When the caller calls this function (which may happen
+        multiple times, to handle multiple requests) this function
+        instantiates the app class (or calls the app function), sandwiched
+        between calls to start_recording() and end_recording() which
+        manipulate the recording state.
+
+        The signature is determined by the WSGI protocol.
+        """
+        recorder = Recorder(environ)
+
+        try:
+            result = app(environ, start_response)
+        except Exception:
+            recorder.status_code = 500
+            log_stats(recorder)
+            raise
+
+        if result is not None:
+            for value in result:
+                yield value
+
+        recorder.status_code = 200
+        log_stats(recorder)
+
+        if hasattr(result, 'close'):
+            result.close()
+
+    return furious_wsgi_wrapper
+
+
+def log_stats(recorder):
+    """Log the request and async stats to the listener."""
+    payload = recorder.get_payload()
+
+    if payload:
+        log_async_info_external(payload)
+
+
+class StatConnection(object):
+
+    def __init__(self, config=None):
+        self._config = config or get_config()
+
+        self._connection_config = (
+            self._config.get('stat_logger_connection', {})
+            if self._config else {})
+
+        self._url = None
+
+    @property
+    def address(self):
+        return self._connection_config.get('address', 'localhost')
+
+    @property
+    def protocol(self):
+        return self._connection_config.get('protocol', CONNECTIONS.HTTP)
+
+    @property
+    def port(self):
+        return int(self._connection_config.get('port', 80))
+
+    @property
+    def deadline(self):
+        return int(self._connection_config.get('deadline', 2))
+
+
+def log_async_info_external(payload):
+    """Log the task info and async information (id, path info, url, etc) to an
+    external logger. It will serialize a json payload to pass to an http, udp,
+    or tcp connection. Add settings are pulled from the config file. If any
+    errors are hit this will fail silently as we don't want this to cause the
+    request to error out. Also sets a 2 second dealine on the request which can
+    be overridden in the config settings.
+    """
+    connection = StatConnection()
+
+    if connection.protocol == CONNECTIONS.HTTP:
+        _log_async_info_to_http(connection, payload)
+    else:
+        _log_async_info_to_socket(connection, payload)
+
+
+def _log_async_info_to_http(connection, payload):
+    """Return a flag for a successful http request to send the payload to the
+    passed in address and port.
+    """
+    try:
+        import urllib2
+
+        url = connection.address
+
+        if not (url and payload):
+            return False
+
+        logging.info("Sending Async Info %s to %s", payload, url)
+
+        urllib2.urlopen(url, data=payload, timeout=connection.deadline)
+
+        return True
+    except Exception, e:
+        logging.info(e)
+        return False
+
+
+def _log_async_info_to_socket(connection, payload):
+    """Return a flag for a successful tcp or udp request to send the payload
+    to the passed in address and port.
+    """
+    import socket
+
+    try:
+        if not connection.address:
+            return False
+
+        connection_port = connection.port or DEFAULT_SOCKET_PORT
+
+        logging.debug("Sending logs to %s:%s", connection.address,
+                      connection_port)
+
+        if not isinstance(connection_port, int):
+            connection_port = int(connection_port)
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(connection.deadline)
+        s.connect((connection.address, connection_port))
+
+        # Add url and request id as a key
+        s.sendall(payload)
+        s.close()
+
+        return True
+
+    except Exception, e:
+        logging.debug(e)
+        return False

--- a/furious/extras/stat_recorder.py
+++ b/furious/extras/stat_recorder.py
@@ -1,0 +1,122 @@
+#
+# Copyright 2013 WebFilings, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""This is a simple RPC recorder based on the App Stats recorder.  It is
+designed to be registered with an App Stats recorder proxy, then called via
+the RPC pre and post hooks.  It collects data on the duration of RPCs.
+"""
+import json
+import logging
+import time
+
+from furious.config import get_module
+
+
+class Recorder(object):
+    """In-memory state for the current request.
+
+    An instance is created soon after the request is received, and
+    set as the Recorder for the current request in the
+    RequestLocalRecorderProxy in the global variable 'recorder_proxy'.  It
+    collects information about the request and about individual RPCs
+    made during the request, until just before the response is sent out,
+    when the recorded information is logged by calling the emit() method.
+    """
+
+    def __init__(self, env):
+        """Constructor.
+
+        Args:
+        env: A dict giving the CGI or WSGI environment.
+        """
+        processor_cls = get_module("stat_processor")
+        self.processor = processor_cls(env, self) if processor_cls else None
+
+        self.start_timestamp = time.time()
+        self.end_timestamp = self.start_timestamp
+        self.env = env
+        self.status_code = None
+
+    def get_payload(self):
+        """Create a dict consisting of the async full id, async function path
+        as the url, request info, application id as the address and combine it
+        with the passed in task info. Then json dumps that and return it.
+        """
+
+        try:
+            payload = self._get_request_info() or {}
+            payload['status_code'] = self.status_code
+            payload['host'] = self._get_host()
+
+            payload.update(self._get_async_details())
+
+            task_stats = self._get_task_stats()
+            if task_stats:
+                payload.update(task_stats)
+
+            payload = json.dumps(payload)
+        except Exception, e:
+            logging.info(e)
+            return None
+
+        return payload
+
+    def _get_async_details(self):
+        """Pull the async from the local context and return the id and function
+        path in a dict if it exists.
+        """
+        from furious.context._local import get_local_context
+
+        context = get_local_context()
+
+        if not context or not context._executing_async_context:
+            return {}
+
+        async = context._executing_async_context.async
+
+        if not async:
+            return {}
+
+        return {
+            'id': async.full_id,
+            'url': async.function_path
+        }
+
+    def _get_request_info(self):
+        if self.processor:
+            return self.processor.get_request_details()
+
+        return {}
+
+    def _get_host(self):
+        if self.processor:
+            return self.processor.get_host()
+
+        return self.env.get('SERVER_NAME')
+
+    def _get_task_stats(self):
+        """Processes the header from task requests to log analytical data."""
+
+        end = time.time()
+        task_stats = {
+            'ran': self.start_timestamp,
+            'end': end,
+            'run_time': end - self.start_timestamp
+        }
+
+        if self.processor:
+            task_stats.update(self.processor.get_task_stats())
+
+        return task_stats

--- a/furious/tests/extras/appengine/test_stat_processor.py
+++ b/furious/tests/extras/appengine/test_stat_processor.py
@@ -1,0 +1,89 @@
+import unittest
+
+from mock import Mock
+
+from furious.extras.appengine.stat_processor import StatProcessor
+
+
+class StatProcessorTestCase(unittest.TestCase):
+
+    def test_get_request_details_exist(self):
+        """Ensure if the request details exist in the environment they are
+        returned.
+        """
+        env = {
+            'APPLICATION_ID': "app+id",
+            'CURRENT_VERSION_ID': 'version_id',
+            'CURRENT_MODULE_ID': 'module-id',
+            'INSTANCE_ID': 'instance&id',
+            'REQUEST_LOG_ID': 'request#id'
+        }
+
+        processor = StatProcessor(env, None)
+
+        self.assertEqual(processor.get_request_details(), {
+            'app_id': 'app_id',
+            'version_id': 'version_id',
+            'module_id': 'module_id',
+            'instance_id': 'instance_id',
+            'request_id': 'request#id'
+        })
+
+    def test_get_request_details_dont_exist(self):
+        """Ensure if the request details exist in the environment they are
+        returned.
+        """
+        processor = StatProcessor(None, None)
+        processor.env = {}
+
+        self.assertEqual(processor.get_request_details(), {
+            'app_id': '',
+            'version_id': '',
+            'module_id': '',
+            'instance_id': '',
+            'request_id': ''
+        })
+
+    def test_get_host_is_server_name(self):
+        """Ensure the SERVER_NAME is returned for the host if it exists."""
+        processor = StatProcessor({'SERVER_NAME': 'sname'}, None)
+
+        self.assertEqual(processor.get_host(), 'sname')
+
+    def test_get_host_is_app_id(self):
+        """Ensure the APPLICATION_ID is returned for the host if it exists and
+        the SERVER_NAME does not.
+        """
+        processor = StatProcessor(None, None)
+        processor.env = {'APPLICATION_ID': 'appid'}
+
+        self.assertEqual(processor.get_host(), 'appid')
+
+    def test_get_host_doesnt_exist(self):
+        """Ensure the NO_APPID is returned if SERVER_NAME and APPLICATION_ID
+        don't exist in the environment.
+        """
+        processor = StatProcessor(None, None)
+        processor.env = {}
+
+        self.assertEqual(processor.get_host(), 'NO_APPID')
+
+    def test_get_task_stats(self):
+        """Ensure the task stats are returned correctly."""
+        env = {
+            'HTTP_X_APPENGINE_TASKETA': 10,
+            'HTTP_X_APPENGINE_TASKRETRYCOUNT': 2,
+            'HTTP_X_APPENGINE_TASKEXECUTIONCOUNT': 3,
+        }
+
+        recorder = Mock()
+        recorder.start_timestamp = 100
+
+        processor = StatProcessor(env, recorder)
+
+        self.assertEqual(processor.get_task_stats(), {
+            'execution_count': 3,
+            'gae_latency_seconds': 90.0,
+            'retry_count': 2,
+            'task_eta': 10.0
+        })

--- a/furious/tests/extras/appengine/test_stat_processor.py
+++ b/furious/tests/extras/appengine/test_stat_processor.py
@@ -44,12 +44,6 @@ class StatProcessorTestCase(unittest.TestCase):
             'request_id': ''
         })
 
-    def test_get_host_is_server_name(self):
-        """Ensure the SERVER_NAME is returned for the host if it exists."""
-        processor = StatProcessor({'SERVER_NAME': 'sname'}, None)
-
-        self.assertEqual(processor.get_host(), 'sname')
-
     def test_get_host_is_app_id(self):
         """Ensure the APPLICATION_ID is returned for the host if it exists and
         the SERVER_NAME does not.

--- a/furious/tests/extras/middleware/test_stat_logger.py
+++ b/furious/tests/extras/middleware/test_stat_logger.py
@@ -1,0 +1,266 @@
+import unittest
+
+from mock import ANY
+from mock import MagicMock
+from mock import Mock
+from mock import patch
+
+
+from furious.extras.middleware.stat_logger import furious_wsgi_middleware
+from furious.extras.middleware.stat_logger import log_stats
+from furious.extras.middleware.stat_logger import StatConnection
+
+
+@patch('furious.extras.middleware.stat_logger.log_stats')
+class FuriousWsgiMiddlewareTestCase(unittest.TestCase):
+
+    def test_200_with_result(self, logger):
+        """Ensure a 200 run logs the stats, yields the results, closes the
+        result and sets a 200 status code.
+        """
+        app_result = iter([1, 2])
+        app = Mock(return_value=app_result)
+        env = {}
+        start_response = Mock()
+
+        wrapper = furious_wsgi_middleware(app)
+
+        result = wrapper(env, start_response)
+
+        self.assertEqual([1, 2], list(result))
+
+        app.assert_called_once_with(env, start_response)
+
+        self.assertEqual(logger.call_args[0][0].status_code, 200)
+
+        logger.assert_called_once_with(ANY)
+
+    def test_200_with_no_result(self, logger):
+        """Ensure a 200 run logs the stats, yields the results, closes the
+        result and sets a 200 status code.
+        """
+        app_result = MagicMock(spec=list)
+        app_result.close = Mock()
+        app = Mock(return_value=app_result)
+        env = {}
+        start_response = Mock()
+
+        wrapper = furious_wsgi_middleware(app)
+
+        result = wrapper(env, start_response)
+
+        self.assertEqual([], list(result))
+
+        app.assert_called_once_with(env, start_response)
+
+        self.assertEqual(logger.call_args[0][0].status_code, 200)
+
+        logger.assert_called_once_with(ANY)
+        app_result.close.assert_called_once_with()
+
+    def test_500_with_result(self, logger):
+        """Ensure a 500 run logs the stats, log the stats but then raises
+        the failure.
+        """
+        app = Mock(side_effect=ValueError)
+        env = {}
+        start_response = Mock()
+
+        wrapper = furious_wsgi_middleware(app)
+
+        self.assertRaises(ValueError, list, wrapper(env, start_response))
+
+        app.assert_called_once_with(env, start_response)
+
+        self.assertEqual(logger.call_args[0][0].status_code, 500)
+
+        logger.assert_called_once_with(ANY)
+
+
+@patch('furious.extras.middleware.stat_logger.StatConnection')
+class LogAsyncInfoExternalTestCase(unittest.TestCase):
+
+    def setUp(self):
+        super(LogAsyncInfoExternalTestCase, self).setUp()
+
+        self.payload = {
+            'foo': 'bar'
+        }
+
+        self.recorder = Mock()
+
+    @patch('urllib2.urlopen')
+    def test_http_connection(self, urlopen, connection):
+        """Ensure a http protocol triggers the http log method."""
+
+        self.recorder.get_payload.return_value = self.payload
+
+        connection.return_value.address = "host"
+        connection.return_value.protocol = "http"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        urlopen.assert_called_once_with('host', data=self.payload,
+                                        timeout=1)
+
+    @patch('urllib2.urlopen')
+    def test_http_connection_failed(self, urlopen, connection):
+        """Ensure a http protocol triggers the http log method and handles
+        the failure.
+        """
+        urlopen.side_effect = ValueError
+
+        self.recorder.get_payload.return_value = self.payload
+
+        connection.return_value.address = "host"
+        connection.return_value.protocol = "http"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        urlopen.assert_called_once_with('host', data=self.payload,
+                                        timeout=1)
+
+    @patch('urllib2.urlopen')
+    def test_http_connection_with_no_url(self, urlopen, connection):
+        """Ensure a http protocol with no url doesn't trigger the http log
+        method.
+        """
+
+        self.recorder.get_payload.return_value = self.payload
+        connection.return_value.address = None
+        connection.return_value.protocol = "http"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        self.assertFalse(urlopen.called)
+
+    @patch('urllib2.urlopen')
+    def test_http_connection_with_no_payload(self, urlopen, connection):
+        """Ensure a http protocol with no payload doesn't trigger the http log
+        method.
+        """
+
+        self.recorder.get_payload.return_value = None
+        connection.return_value.address = "host"
+        connection.return_value.protocol = "http"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        self.assertFalse(urlopen.called)
+
+    @patch('socket.socket')
+    def test_socket_connection(self, socket, connection):
+        """Ensure a socket protocol triggers the socket log method."""
+
+        self.recorder.get_payload.return_value = self.payload
+        connection.return_value.address = "host"
+        connection.return_value.protocol = "tcp"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        socket.assert_called_once_with(2, 1)
+        socket.return_value.settimeout.assert_called_once_with(1)
+        socket.return_value.connect.assert_called_once_with(('host', 1))
+        socket.return_value.sendall.assert_called_once_with(self.payload)
+        socket.return_value.close.assert_called_once_with()
+
+    @patch('socket.socket')
+    def test_socket_connection_fails(self, socket, connection):
+        """Ensure a socket protocol triggers the socket log method and handles
+        the failure.
+        """
+        socket.return_value.connect.side_effect = ValueError
+
+        self.recorder.get_payload.return_value = self.payload
+        connection.return_value.address = "host"
+        connection.return_value.protocol = "tcp"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        socket.assert_called_once_with(2, 1)
+        socket.return_value.settimeout.assert_called_once_with(1)
+        socket.return_value.connect.assert_called_once_with(('host', 1))
+        self.assertFalse(socket.return_value.sendall.called)
+        self.assertFalse(socket.return_value.close.called)
+
+    @patch('socket.socket')
+    def test_socket_connection_with_no_host(self, socket, connection):
+        """Ensure a socket protocol with no host doesn't trigger the socket log
+        method.
+        """
+
+        self.recorder.get_payload.return_value = self.payload
+        connection.return_value.address = None
+        connection.return_value.protocol = "tcp"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        self.assertFalse(socket.called)
+
+    @patch('socket.socket')
+    def test_socket_connection_with_no_payload(self, socket, connection):
+        """Ensure a socket protocol with no payload doesn't trigger the socket
+        log method.
+        """
+
+        self.recorder.get_payload.return_value = None
+        connection.return_value.address = "host"
+        connection.return_value.protocol = "tcp"
+        connection.return_value.deadline = 1
+
+        log_stats(self.recorder)
+
+        self.assertFalse(socket.called)
+
+    @patch('socket.socket')
+    def test_connection_with_no_protocol(self, socket, connection):
+        """Ensure an address with no protocol triggers the default socket
+        method.
+        """
+
+        self.recorder.get_payload.return_value = self.payload
+        connection.return_value.address = "host"
+        connection.return_value.protocol = None
+        connection.return_value.deadline = 1
+        connection.return_value.port = 100
+
+        log_stats(self.recorder)
+
+        socket.assert_called_once_with(2, 1)
+        socket.return_value.settimeout.assert_called_once_with(1)
+        socket.return_value.connect.assert_called_once_with(('host', 100))
+        socket.return_value.sendall.assert_called_once_with(self.payload)
+        socket.return_value.close.assert_called_once_with()
+
+
+@patch('furious.extras.middleware.stat_logger.get_config')
+class StatConnectionTestCase(unittest.TestCase):
+
+    def test_stat_connection_loads_config(self, get_config):
+        """Ensure if no config is passed in it loads the config."""
+        cfg = {
+            'stat_logger_connection': {
+                'address': 'addr',
+                'protocol': 'proto',
+                'port': 90,
+                'deadline': 5
+            }
+        }
+
+        get_config.return_value = cfg
+
+        connection = StatConnection(config=None)
+
+        self.assertEqual(connection._config, cfg)
+
+        self.assertEqual(connection.address, 'addr')
+        self.assertEqual(connection.protocol, 'proto')
+        self.assertEqual(connection.port, 90)
+        self.assertEqual(connection.deadline, 5)

--- a/furious/tests/extras/test_stat_recorder.py
+++ b/furious/tests/extras/test_stat_recorder.py
@@ -1,0 +1,168 @@
+import json
+import unittest
+
+from mock import Mock
+from mock import patch
+
+from furious.extras.stat_recorder import Recorder
+
+
+@patch('furious.extras.stat_recorder.get_module')
+class RecorderTestCase(unittest.TestCase):
+
+    def test_recorder_has_processor(self, get_module):
+        """Ensure the processor is set if it exists in the config."""
+        env = {}
+        processor = Mock()
+
+        get_module.return_value = processor
+
+        recorder = Recorder(env)
+
+        get_module.assert_called_once_with("stat_processor")
+
+        self.assertIsNotNone(recorder.start_timestamp)
+        self.assertEqual(recorder.start_timestamp, recorder.end_timestamp)
+        self.assertEqual(recorder.env, env)
+        self.assertIsNone(recorder.status_code)
+        self.assertEqual(recorder.processor, processor.return_value)
+
+    def test_recorder_has_no_processor(self, get_module):
+        """Ensure the processor is set to None if it doesn't exist in the
+        config.
+        """
+        env = {}
+
+        get_module.return_value = None
+
+        recorder = Recorder(env)
+
+        get_module.assert_called_once_with("stat_processor")
+
+        self.assertIsNotNone(recorder.start_timestamp)
+        self.assertEqual(recorder.start_timestamp, recorder.end_timestamp)
+        self.assertEqual(recorder.env, env)
+        self.assertIsNone(recorder.status_code)
+        self.assertIsNone(recorder.processor)
+
+    @patch('furious.extras.stat_recorder.time.time')
+    def test_get_payload_with_stats_no_processor(self, get_time, get_module):
+        """Ensure get payload returns the expeted results with task stats
+        included.
+        """
+        get_time.side_effect = (1, 2)
+        get_module.return_value = None
+
+        recorder = Recorder({})
+
+        payload = recorder.get_payload()
+
+        self.assertEqual(json.loads(payload), json.loads(json.dumps({
+            "ran": 1,
+            "status_code": None,
+            "host": None,
+            "end": 2,
+            "run_time": 1
+        })))
+
+    @patch('furious.extras.stat_recorder.time.time')
+    def test_get_payload_with_stats_with_processor(self, get_time, get_module):
+        """Ensure get payload returns the expeted results with task stats
+        included.
+        """
+        get_time.side_effect = (1, 2)
+
+        processor = Mock()
+        get_module.return_value = processor
+
+        processor.return_value.get_request_details.return_value = {
+            'preq': 'foo'
+        }
+
+        processor.return_value.get_host.return_value = "phost"
+        processor.return_value.get_task_stats.return_value = {
+            'pstats': 'bar'
+        }
+
+        recorder = Recorder({})
+
+        payload = recorder.get_payload()
+
+        self.assertEqual(json.loads(payload), json.loads(json.dumps({
+            "preq": "foo",
+            "ran": 1,
+            "status_code": None,
+            "host": "phost",
+            "end": 2,
+            "run_time": 1,
+            "pstats": "bar"
+        })))
+
+    def test_get_payload_with_stats_with_processor_raises(self, get_module):
+        """Ensure get payload that raises returns None."""
+        processor = Mock()
+        processor.get_request_details.side_effect = ValueError
+        get_module.return_value = processor
+
+        recorder = Recorder({})
+
+        payload = recorder.get_payload()
+
+        self.assertIsNone(payload)
+
+    @patch('furious.context._local.get_local_context')
+    def test_get_async_details(self, get_context, get_module):
+        """Ensure if the async is found that the id and function path are
+        returned in a dict.
+        """
+        async = Mock()
+        async.full_id = "fullid"
+        async.function_path = "funcpath"
+
+        context = Mock()
+        context._executing_async_context.async = async
+        get_context.return_value = context
+
+        recorder = Recorder({})
+
+        self.assertEqual(recorder._get_async_details(), {
+            'id': 'fullid',
+            'url': 'funcpath'
+        })
+
+    @patch('furious.context._local.get_local_context')
+    def test_get_async_details_with_no_context(self, get_context, get_module):
+        """Ensure if no context is found that an empty dict is returned."""
+        get_context.return_value = None
+
+        recorder = Recorder({})
+
+        self.assertEqual(recorder._get_async_details(), {})
+
+    @patch('furious.context._local.get_local_context')
+    def test_get_async_details_with_no_executing_context(self, get_context,
+                                                         get_module):
+        """Ensure if no _executing_async_context is on the context that an
+        empty dict is returned.
+        """
+        context = Mock()
+        context._executing_async_context = None
+        get_context.return_value = context
+
+        recorder = Recorder({})
+
+        self.assertEqual(recorder._get_async_details(), {})
+
+    @patch('furious.context._local.get_local_context')
+    def test_get_async_details_with_no_async(self, get_context, get_module):
+        """Ensure if no async is on the _executing_async_context that an
+        empty dict is returned.
+        """
+        context = Mock()
+        context._executing_async_context.async = None
+        get_context.return_value = context
+
+        recorder = Recorder({})
+
+        self.assertEqual(recorder._get_async_details(), {})
+

--- a/furious/tests/test_config.py
+++ b/furious/tests/test_config.py
@@ -125,6 +125,44 @@ class TestConfigurationLoading(unittest.TestCase):
 
         self.assertEqual(module, async)
 
+    def test_get_configured_module_by_name_is_invlid_path(self):
+        """Ensure _get_configured_module raises when trying to load non
+        existing options by name.
+        """
+        from furious.config import _get_configured_module
+        from furious.errors import BadObjectPathError
+        from furious import config
+
+        config.get_config()['other_option'] = 'cfg'
+
+        self.assertRaises(BadObjectPathError, _get_configured_module,
+                          'other_option')
+
+    def test_get_configured_module_by_name_doesnt_exist_no_verify(self):
+        """Ensure _get_configured_module raises when trying to load non
+        existing options by name.
+        """
+        from furious.config import _get_configured_module
+
+        self.assertRaises(KeyError, _get_configured_module,
+                          'other_option')
+
+    def test_get_configured_module_by_name_doesnt_exist_no_verify(self):
+        """Ensure _get_configured_module raises when trying to load non
+        existing options by name.
+        """
+        from furious.config import _get_configured_module
+
+        self.assertRaises(KeyError, _get_configured_module,
+                          'other_option')
+
+    def test_get_configured_module_by_name_doesnt_exist_with_verify(self):
+        """Ensure _get_configured_module loads options by name."""
+        from furious.config import _get_configured_module
+
+        self.assertRaises(KeyError, _get_configured_module,
+                          'other_option')
+
     def test_get_config_empty_yaml(self):
         """Ensure an empty furious.yaml will produce a default config."""
         from furious.config import default_config
@@ -135,4 +173,3 @@ class TestConfigurationLoading(unittest.TestCase):
         my_config = _parse_yaml_config(example_yaml)
 
         self.assertEqual(my_config, default_config())
-


### PR DESCRIPTION
Add middleware extra that will send request and async stats to a configured listener.

Example config

``` py
stat_processor: furious.extras.appengine.stat_processor.StatProcessor
stat_logger_connection:
  address: http://127.0.0.1:3000/api/tasks/
  protocol: http
  deadline: 2
```

@robertkluin-wf @johnlockwood-wf @tannermiller-wf @rosshendrickson-wf @macleodbroad-wf @tylertreat-wf
