### PR TITLE
Fix the error callback example

### DIFF
--- a/example/callback.py
+++ b/example/callback.py
@@ -128,12 +128,13 @@ def handle_an_error():
 
     from furious.context import get_current_async
 
-    exception_info = get_current_async().result
-
-    logging.info('async job blew up, exception info: %r', exception_info)
+    async = get_current_async()
+    async_exception = async.result.payload
+    exc_info = async_exception.traceback
+    logging.info('async job blew up, exception info: %r', exc_info)
 
     retries = int(os.environ['HTTP_X_APPENGINE_TASKRETRYCOUNT'])
     if retries < 2:
-        raise exception_info.exception
+        raise Exception(async_exception.error)
     else:
         logging.info('Caught too many errors, giving up now.')


### PR DESCRIPTION
This fixes the example to show how you can assign an async to be executed if there is an unhanded exception in your own async. Due to changes with how we handle results this example no longer work and was throwing its own exceptions trying to access properties that no longer existed. This fixes that. 

I think the expected behavior of the error callback example is to re-raise the exception that was found in the other task. 

@beaulyddon-wf @tylertreat @tannermiller-wf @ericolson-wf @stevenosborne-wf 
