### PR TITLE
Transient error retry on start

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -332,6 +332,7 @@ class Async(object):
         task = self.to_task()
         queue = taskqueue.Queue(name=self.get_queue())
         retry_transient = self._options.get('retry_transient_errors', True)
+        retry_delay = self._options.get('retry_delay', RETRY_SLEEP_SECS)
 
         add = queue.add
         if async:
@@ -344,7 +345,7 @@ class Async(object):
                 raise
 
             import time
-            time.sleep(RETRY_SLEEP_SECS)
+            time.sleep(retry_delay)
 
             ret = add(task, transactional=transactional)
         except (taskqueue.TaskAlreadyExistsError,

--- a/furious/async.py
+++ b/furious/async.py
@@ -342,7 +342,9 @@ class Async(object):
         try:
             ret = add(task, transactional=transactional)
         except taskqueue.TransientError:
-            if not retry_transient:
+            # Always re-raise for transactional insert, or if specified by
+            # options.
+            if transactional or not retry_transient:
                 raise
 
             time.sleep(retry_delay)

--- a/furious/async.py
+++ b/furious/async.py
@@ -72,6 +72,7 @@ from functools import partial
 from functools import wraps
 import json
 import os
+import time
 import uuid
 
 from furious.job_utils import decode_callbacks
@@ -344,7 +345,6 @@ class Async(object):
             if not retry_transient:
                 raise
 
-            import time
             time.sleep(retry_delay)
 
             ret = add(task, transactional=transactional)
@@ -593,8 +593,6 @@ def encode_async_options(async):
     # JSON don't like datetimes.
     eta = options.get('task_args', {}).get('eta')
     if eta:
-        import time
-
         options['task_args']['eta'] = time.mktime(eta.timetuple())
 
     callbacks = async._options.get('callbacks')

--- a/furious/context/context.py
+++ b/furious/context/context.py
@@ -402,7 +402,9 @@ def _insert_tasks(tasks, queue, transactional=False,
 
         return inserted
     except taskqueue.TransientError:
-        if not retry_transient_errors:
+        # Always re-raise for transactional insert, or if specified by
+        # options.
+        if transactional or not retry_transient_errors:
             raise
 
         reinsert = _tasks_to_reinsert(tasks, transactional)

--- a/furious/tests/context/test_context.py
+++ b/furious/tests/context/test_context.py
@@ -487,14 +487,18 @@ class TestInsertTasks(unittest.TestCase):
     @patch('time.sleep')
     @patch('google.appengine.api.taskqueue.Queue.add', auto_spec=True)
     def test_task_add_error_TransientError(self, queue_add_mock, mock_sleep):
-        """Ensure a TransientError doesn't get raised from add."""
+        """Ensure a TransientError gets raised from add if we've specified not
+        to retry those errors."""
         from furious.context.context import _insert_tasks
         from google.appengine.api import taskqueue
         queue_add_mock.side_effect = taskqueue.TransientError
 
-        inserted = _insert_tasks(('A',), 'AbCd', retry_errors=False)
+        self.assertRaises(
+            taskqueue.TransientError,
+            _insert_tasks, ('A',), 'AbCd', retry_transient_errors=False
+        )
+
         queue_add_mock.assert_called_once_with(('A',), transactional=False)
-        self.assertEqual(0, inserted)
 
     @patch('time.sleep')
     @patch('google.appengine.api.taskqueue.Queue.add', auto_spec=True)

--- a/furious/tests/test_async.py
+++ b/furious/tests/test_async.py
@@ -725,14 +725,15 @@ class TestAsync(unittest.TestCase):
         self.assertEqual(1, queue_mock.return_value.add.call_count)
 
         # Try again with the option enabled, this should cause a retry after a
-        # delay.
+        # delay, which we have also specified.
         queue_mock.reset_mock()
         async_job = Async("something", queue='my_queue',
-                          retry_transient_errors=True)
+                          retry_transient_errors=True,
+                          retry_delay=12)
 
         self.assertRaises(TransientError, async_job.start)
         self.assertEqual(2, queue_mock.return_value.add.call_count)
-        self.assertEqual(1, sleep_mock.call_count)
+        sleep_mock.assert_called_once_with(12)
 
     @mock.patch('google.appengine.api.taskqueue.Queue', autospec=True)
     def test_start_hits_other_error_retry_enabled(self, queue_mock):

--- a/furious/tests/test_async.py
+++ b/furious/tests/test_async.py
@@ -683,8 +683,9 @@ class TestAsync(unittest.TestCase):
         persistence_engine.store_async_result.assert_called_once_with(job.id,
                                                                       result)
 
+    @mock.patch('time.sleep')
     @mock.patch('google.appengine.api.taskqueue.Queue', autospec=True)
-    def test_start_hits_transient_error(self, queue_mock):
+    def test_start_hits_transient_error(self, queue_mock, mock_sleep):
         """Ensure the task retries if a transient error is hit."""
         from google.appengine.api.taskqueue import TransientError
         from furious.async import Async
@@ -703,6 +704,51 @@ class TestAsync(unittest.TestCase):
 
         queue_mock.assert_called_with(name='my_queue')
         self.assertEqual(2, queue_mock.return_value.add.call_count)
+        self.assertEqual(1, mock_sleep.call_count)
+
+    @mock.patch('time.sleep')
+    @mock.patch('google.appengine.api.taskqueue.Queue', autospec=True)
+    def test_start_hits_transient_error_retry_disabled(self, queue_mock,
+                                                       sleep_mock):
+        """Ensure if transient error retries are disabled, that those errors are
+        re-raised immediately without any attempt to re-insert.
+        """
+        from google.appengine.api.taskqueue import TransientError
+        from furious.async import Async
+
+        queue_mock.return_value.add.side_effect = TransientError()
+
+        async_job = Async("something", queue='my_queue',
+                          retry_transient_errors=False)
+
+        self.assertRaises(TransientError, async_job.start)
+        self.assertEqual(1, queue_mock.return_value.add.call_count)
+
+        # Try again with the option enabled, this should cause a retry after a
+        # delay.
+        queue_mock.reset_mock()
+        async_job = Async("something", queue='my_queue',
+                          retry_transient_errors=True)
+
+        self.assertRaises(TransientError, async_job.start)
+        self.assertEqual(2, queue_mock.return_value.add.call_count)
+        self.assertEqual(1, sleep_mock.call_count)
+
+    @mock.patch('google.appengine.api.taskqueue.Queue', autospec=True)
+    def test_start_hits_other_error_retry_enabled(self, queue_mock):
+        """Ensure if transient error retries are enabled, that other errors are
+        not retried.
+        """
+
+        from furious.async import Async
+
+        queue_mock.return_value.add.side_effect = (Exception(), None)
+
+        async_job = Async("something", queue='my_queue',
+                          retry_transient_errors=True)
+
+        self.assertRaises(Exception, async_job.start)
+        self.assertEqual(1, queue_mock.return_value.add.call_count)
 
     @mock.patch('google.appengine.api.taskqueue.Queue', autospec=True)
     def test_start_hits_task_already_exists_error_error(self, queue_mock):


### PR DESCRIPTION
Re-opened PR against Workiva/furious

Original PR here: https://github.com/markshaule-wf/furious/pull/1

Async Changes:
Async.start() now sleeps before attempting to re-add task on a TransientError.
Add option retry_transient_errors to override the retry behaviour in Async.start(). False can be specified to just re-raise the TransientError, and not attempt a retry.

Context Changes:
Context _insert_tasks now re-raises TransientError if retry option has been set to False.
Renamed parameter 'retry_errors' to 'retry_transient_errors' in _insert_tasks function.
_insert_tasks - retry_transient_errors parameter is now passed onto recursive calls correctly.

Notes on compatibility:
Since I've renamed the parameter for _insert_tasks, that could potentially break someone's custom implementation of that function.
