### PR TITLE
Add info needed to add Furious to the public pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ doc/source/*
 !doc/source/design*.txt
 !doc/source/_static/*
 !doc/source/_templates/*
+
+bilobac
+dist/
+furious.egg-info/

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ cover-branches=True
 
 exclude-dir=furious/tests/dummy_module
 ATTR=!slow
+
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup_args = dict(
     description='Furious is a lightweight library that wraps Google App Engine'
                 'taskqueues to make building dynamic workflows easy.',
     author='Robert Kluin',
-    author_email='robert.kluin@webfilings.com',
-    url='http://github.com/WebFilings/furious',
+    author_email='robert.kluin@workiva.com',
+    url='http://github.com/Workiva/furious',
     packages=find_packages(exclude=['example']),
     download_url = "https://github.com/Workiva/furious/tarball/v1.3.0",
     keywords = ['async', 'gae', 'appengine', 'taskqueue'],

--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,17 @@ setup_args = dict(
     author_email='robert.kluin@webfilings.com',
     url='http://github.com/WebFilings/furious',
     packages=find_packages(exclude=['example']),
+    download_url = "https://github.com/Workiva/furious/tarball/v1.3.0",
+    keywords = ['async', 'gae', 'appengine', 'taskqueue'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: Apache',
+        'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
 )
-
 
 if __name__ == '__main__':
     setup(**setup_args)


### PR DESCRIPTION
Since Furious is open source we should be good people and add our lib to pypi so
others can easily use it via pip/easy_install and not be required to build from
source.

I've added the required info to setup.py and setup.cfg. Wasn't much. Also added
the generated pypi files to the .gitignore so we don't push those up.

@robertkluin @nickjoyce-wf @shawnrusaw-wf @tylertreat @tannermiller-wf 

FYI @chadknight-wf for the request