### PR TITLE
Update examples to have the correct furious handler

### DIFF
--- a/example/__init__.py
+++ b/example/__init__.py
@@ -40,13 +40,17 @@ from .grep import GrepHandler
 from .simple_workflow import SimpleWorkflowHandler
 from .limits import LimitHandler
 
+from furious.handlers.webapp import AsyncJobHandler
+
 config = {
     'webapp2_extras.jinja2': {
         'template_path': 'example/templates'
     }
 }
 
+
 app = webapp2.WSGIApplication([
+    ('/_queue/async.*', AsyncJobHandler),
     ('/', AsyncIntroHandler),
     ('/abort_and_restart', AbortAndRestartHandler),
     ('/context', ContextIntroHandler),


### PR DESCRIPTION
The examples should work now. I'm not sure why the queue base URL change affected the handling of the tasks but backing up to the commit prior to that one and the URL handling is fine. I did this little tweak  to get it working. I suspected that the * in the app yaml routing before the change was being handled differently but after a bunch of searching I was not able to find what actually was handling the furious calls (to my chagrin). Was hacking on some completion stuff and couldn't get the examples to work so I carved this off to get it looked at first.

@beaulyddon-wf @tylertreat @tannermiller-wf 