### PR TITLE
encode / decode _process_results option

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -596,6 +596,10 @@ def encode_async_options(async):
         _checker = options.pop('_context_checker')
         options['__context_checker'] = reference_to_path(_checker)
 
+    if '_process_results' in options:
+        _processor = options.pop('_process_results')
+        options['__process_results'] = reference_to_path(_processor)
+
     return options
 
 
@@ -619,6 +623,9 @@ def decode_async_options(options):
         _checker = options['__context_checker']
         async_options['_context_checker'] = path_to_reference(_checker)
 
+    if '__process_results' in options:
+        _processor = options['__process_results']
+        async_options['_process_results'] = path_to_reference(_processor)
     return async_options
 
 

--- a/furious/tests/test_async.py
+++ b/furious/tests/test_async.py
@@ -961,6 +961,22 @@ class TestAsync(unittest.TestCase):
 
         self.assertEqual(async_job.to_dict(), new_async_job.to_dict())
 
+    def test_process_results_encoded_and_decoded(self):
+        """Ensure _process_results is correctly encoded to and decoded from
+        an Async options dict.
+        """
+        from furious.async import Async
+
+        async_job = Async("something", _process_results=locals)
+
+        encoded_async = async_job.to_dict()
+        self.assertEqual(encoded_async['__process_results'], 'locals')
+
+        new_async_job = Async.from_dict(encoded_async)
+        self.assertEqual(new_async_job.get_options()['_process_results'], locals)
+
+        self.assertEqual(async_job.to_dict(), new_async_job.to_dict())
+
     def test_retry_value_is_decodable(self):
         """Ensure that from_dict is the inverse of to_dict when retry options
         are given.


### PR DESCRIPTION
currently, the _process_results option is not correctly encoded/decoded with the rest of the async options.  passing in a callable will result in a json error.  this change handles _process_results exactly like _context_checker is currently handled.

@beaulyddon-wf @tannermiller-wf