### PR TITLE
Async subclasses can now decorate their target functions

### DIFF
--- a/furious/async.py
+++ b/furious/async.py
@@ -173,6 +173,16 @@ class Async(object):
         return self._persistence_engine.store_async_result(
             self.id, self.result)
 
+    def _decorate_job(self):
+        """Returns the job function.
+
+        A subclass may override `Async._decorate_job` in order to wrap the
+        original target using a decorator function.
+        """
+        function_path = self.job[0]
+        func = path_to_reference(function_path)
+        return func
+
     @property
     def function_path(self):
         return self.job[0]

--- a/furious/processors.py
+++ b/furious/processors.py
@@ -42,7 +42,7 @@ def run_job():
     if not job:
         raise Exception('This async contains no job to execute!')
 
-    function_path, args, kwargs = job
+    __, args, kwargs = job
 
     if args is None:
         args = ()
@@ -50,7 +50,7 @@ def run_job():
     if kwargs is None:
         kwargs = {}
 
-    function = path_to_reference(function_path)
+    function = async._decorate_job()
 
     try:
         async.executing = True


### PR DESCRIPTION
There's a couple reasons you'd want to leverage this:
1. Instead of decorating every target function's definition, just use the
   appropriate Async type.
2. When you only want the decorated function for tasks.

Examples of the latter, where you'd want extra functionality for the Task but
not when using the target function as a normal local procedure call, would be:
- logging out extra context for the task
- top-level try/except handling for the task
- a retry loop, instead of just kicking off a new task when a transient error
  happens

@markshaule-wf @andreleblanc-wf @beaulyddon-wf @tylertreat 

FYI @macleodbroad-wf