### PR TITLE
Move imports inside of csrf_check

### DIFF
--- a/furious/__init__.py
+++ b/furious/__init__.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-import logging
-
-import webapp2
-
 
 def csrf_check(request):
     """
@@ -25,6 +21,9 @@ def csrf_check(request):
 
     https://cloud.google.com/appengine/docs/standard/python/refdocs/modules/google/appengine/ext/deferred/deferred
     """
+    import logging
+    import webapp2
+    
     in_prod = (
         not request.environ.get("SERVER_SOFTWARE").startswith("Devel"))
     if in_prod and request.environ.get("REMOTE_ADDR") != "0.1.0.2":

--- a/furious/_pkg_meta.py
+++ b/furious/_pkg_meta.py
@@ -1,2 +1,2 @@
-version_info = (1, 6, 4)
+version_info = (1, 6, 5)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION
Doing this import at the top-level is causing some consumers' tests to have a bad time.