### PR TITLE
RED-5108 - Fixing import error

### DIFF
--- a/furious/__init__.py
+++ b/furious/__init__.py
@@ -13,21 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import logging
-
-import webapp2
-
-
-def csrf_check(request):
-    """
-    Throws an HTTP 403 error if a CSRF attack is detected, same logic as the deferred module.
-
-    https://cloud.google.com/appengine/docs/standard/python/refdocs/modules/google/appengine/ext/deferred/deferred
-    """
-    in_prod = (
-        not request.environ.get("SERVER_SOFTWARE").startswith("Devel"))
-    if in_prod and request.environ.get("REMOTE_ADDR") != "0.1.0.2":
-      logging.error("Detected an attempted CSRF attack from {}. This request did "
-                    "not originate from Task Queue.".format(request.environ.get("REMOTE_ADDR")))
-      webapp2.abort(403)

--- a/furious/config.py
+++ b/furious/config.py
@@ -165,7 +165,7 @@ def default_config():
             'cleanupdelay': 7600,
             'defaultqueue': 'default',
             'task_system': 'appengine_taskqueue',
-            'csrf_check': 'furious.csrf_check'}
+            'csrf_check': 'furious.handlers.webapp.csrf_check'}
 
 
 def _load_yaml_config(path=None):


### PR DESCRIPTION
Some consumers don't have `webapp2` in their import path when loading `furious/__init__.py` so we have to move the webapp2 logic all into the `webapp.py` file.